### PR TITLE
Move to startup probes, and longer termination delay (CU-86cxwpery)

### DIFF
--- a/charts/zudello-helm/Chart.yaml
+++ b/charts/zudello-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.25.0
+version: 6.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -33,14 +33,14 @@ A port can also be set as the third option, if not specified, it defaults to 800
             httpGet:
               path: {{ $healthPath }}?liveness
               port: {{ $port }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 15
             timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: {{ $healthPath }}?readiness
               port: {{ $port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 15
             timeoutSeconds: 5
             periodSeconds: 3
 {{ end -}} {{/* if $values.developmentMode */}}

--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -1,7 +1,9 @@
 {{- define "zudello.django-liveness-readiness" -}}
 {{/*
 
-Typical set of liveness and readiness probes for django applications.
+Typical set of liveness and startup probes for django applications.
+
+(Note: There is no actual readiness probe as this is generally not applicable to us)
 
 Automatically disables the checks if developmentMode is true
 

--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -65,7 +65,7 @@ Normal usage:
             preStop:
               exec:
                 # Take at least 20 seconds, plus remaining request processing time to shutdown as the AWS ELB can take that long to stop sending requests to the pod
-                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 61s (lifecycle:preStop)' >> /proc/1/fd/1; sleep 61"]
+                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 55s (lifecycle:preStop)' >> /proc/1/fd/1; sleep 55"]
 {{ end -}} {{/* if $values.developmentMode */}}
 {{ end -}} {{/* zudello.django-lifecycle */}}
 

--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -33,16 +33,17 @@ A port can also be set as the third option, if not specified, it defaults to 800
             httpGet:
               path: {{ $healthPath }}?liveness
               port: {{ $port }}
-            initialDelaySeconds: 15
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: {{ $healthPath }}?readiness
+              path: {{ $healthPath }}?startup
               port: {{ $port }}
-            initialDelaySeconds: 15
+            initialDelaySeconds: 3
             timeoutSeconds: 5
             periodSeconds: 3
+            failureThreshold: 30
 {{ end -}} {{/* if $values.developmentMode */}}
 {{- end -}} {{/* zudello.django-liveness-readiness */}}
 
@@ -63,8 +64,8 @@ Normal usage:
           lifecycle:
             preStop:
               exec:
-                # Take at least 20 seconds to shutdown as the AWS ELB can take that long to stop sending requests to the pod
-                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 21s (lifecycle:preStop)' >> /proc/1/fd/1; sleep 21"]
+                # Take at least 20 seconds, plus remaining request processing time to shutdown as the AWS ELB can take that long to stop sending requests to the pod
+                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 61s (lifecycle:preStop)' >> /proc/1/fd/1; sleep 61"]
 {{ end -}} {{/* if $values.developmentMode */}}
 {{ end -}} {{/* zudello.django-lifecycle */}}
 


### PR DESCRIPTION
Theory: It is possible that `uvicorn` does not start serving within the first 5 seconds, causing the `readinessProbe` to fail.