### PR TITLE
Mark `preStop` signal so that we can fail readiness checks

### DIFF
--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -64,7 +64,7 @@ Normal usage:
             preStop:
               exec:
                 # Take at least 20 seconds to shutdown as the AWS ELB can take that long to stop sending requests to the pod
-                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 21s (lifecycle:preStop)' >> /proc/1/fd/1; sleep 21"]
+                command: ["bash", "-c", "echo `date -Is` 'Terminating pod in 21s (lifecycle:preStop)' >> /proc/1/fd/1; touch /tmp/preStop; sleep 21"]
 {{ end -}} {{/* if $values.developmentMode */}}
 {{ end -}} {{/* zudello.django-lifecycle */}}
 


### PR DESCRIPTION
Apparently readiness checks are still being sent by k8s after a preStop signal, and the load balancer still routes to the pods that are in terminating state.

This is an experimental change to create a marker file so that we can fail readiness (but not liveness!!!) checks from the Django app.