### PR TITLE
Add annotations for the configured replica counts

### DIFF
--- a/charts/zudello-helm/Chart.yaml
+++ b/charts/zudello-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.34.0
+version: 6.35.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zudello-helm/templates/_django_helpers.tpl
+++ b/charts/zudello-helm/templates/_django_helpers.tpl
@@ -213,6 +213,9 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name | quote }}
   namespace: {{ $values.namespace | quote }}
+  annotations:
+    zudello.com/minReplicas: "{{ $values.minimumWebReplicas }}"
+    zudello.com/maxReplicas: "{{ $values.maximumWebReplicas }}"
 spec:
   minReplicas: {{ required "minimumWebReplicas must be set" $values.minimumWebReplicas }}
   maxReplicas: {{ required "maximumWebReplicas must be set" $values.maximumWebReplicas }}

--- a/charts/zudello-helm/templates/_rabbitmq_helpers.tpl
+++ b/charts/zudello-helm/templates/_rabbitmq_helpers.tpl
@@ -512,6 +512,9 @@ kind: ScaledObject
 metadata:
   name: {{ $queue.name }}
   namespace: {{ $values.namespace | quote }}
+  annotations:
+    zudello.com/minReplicas: "{{ $queue.minimumReplicas }}"
+    zudello.com/maxReplicas: "{{ $queue.maximumReplicas }}"
 spec:
   scaleTargetRef:
     name: {{ $queue.name }}


### PR DESCRIPTION
Used if the replica count is manually modified, to allow easy restoration of cluster configured defaults