### PR TITLE
Label rabbit secrets as required for upcoming topology-operator updates

### DIFF
--- a/charts/zudello-helm/Chart.yaml
+++ b/charts/zudello-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.40.0
+version: 6.41.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zudello-helm/templates/_rabbitmq_helpers.tpl
+++ b/charts/zudello-helm/templates/_rabbitmq_helpers.tpl
@@ -126,6 +126,8 @@ metadata:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-11"
+  labels:
+    rabbitmq.com/topology-operator: "true"
 type: Opaque
 
 {{ end }}{{/* if not $rabbitPassword */}}
@@ -372,6 +374,8 @@ metadata:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-11"
+  labels:
+    rabbitmq.com/topology-operator: "true"
 type: Opaque
 
 {{ end }}{{/* if not $rabbitPassword */}}
@@ -471,6 +475,8 @@ data:
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
+  labels:
+    rabbitmq.com/topology-operator: "true"
 type: Opaque
 
 ---


### PR DESCRIPTION
Add a `rabbitmq.com/topology-operator=true` label to all RabbitMQ related secrets as recent `rabbit-topology-operator` updates require this to access the secret.

#86d3v5fzp